### PR TITLE
Removed enforced HTTPS from header

### DIFF
--- a/views/home.ejs
+++ b/views/home.ejs
@@ -3,9 +3,9 @@
     <head>
         <meta charset='utf-8'>
         <title>Family Todo List</title>
-        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.0/css/bulma.min.css"/>
+        <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/bulma@0.9.0/css/bulma.min.css"/>
         <link rel="stylesheet" type="text/css" href="/css/stylesheet.css"/>
-        <script defer src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
+        <script defer src="//ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
         <script defer src='./JQuery/main.js'></script>
     </head>
     <body>


### PR DESCRIPTION
Removed enforced HTTPS from header to allow HTTP to be used when HTTPS isn't available. 

Fixes #8 